### PR TITLE
1.2.0: ufretのHTML構造変更に伴うスクレイピング修正

### DIFF
--- a/backend/implements/home-info.js
+++ b/backend/implements/home-info.js
@@ -1,19 +1,7 @@
 const express = require('express');
 
-const {
-    loadUrl,
-    isDisplay,
-    getArtistName,
-    isSongListGroupItem,
-    getSongId,
-    isArtistListGroupItem,
-    getRankingNumber,
-    getSongName,
-    getArtistNameOfSong,
-    getArtistId,
-    hasExcludeBadge
-} = require('../utils/cheerio');
-    
+const { loadUrl } = require('../utils/cheerio');
+
 const router = express.Router();
 
 exports.getHomeInfo = async (req, res) => {
@@ -21,44 +9,41 @@ exports.getHomeInfo = async (req, res) => {
         const $ = await loadUrl(`https://www.ufret.jp/`);
         const songs = [];
         const artists = [];
+        let songRank = 0;
+        let artistRank = 0;
 
-        $('a.list-group-item').each((_, element) => {
-            if (isSongListGroupItem($(element))) {
-                // 見えていない要素は無視する
-                if (!isDisplay($(element))) { return }
-                // 除外対象の場合は無視する
-                if (hasExcludeBadge($(element))) { return }
+        // 曲ランキング（ul.c-card-song の最初のブロックのみ＝今週のランキング）
+        $('ul.c-card-song').first().find('li.c-card-song__item').each((_, element) => {
+            const link = $(element).find('a[href*="song.php"]');
+            const href = link.attr('href') || '';
 
-                const songId = getSongId($(element));
-                const name = getSongName($(element));
-                const artist = getArtistNameOfSong($(element));
-                const rank = getRankingNumber($(element));
+            // 初心者バッジがある場合は除外
+            if (link.find('div.c-card-song__badge span.badge-info').length > 0) { return; }
 
-                if (!songId || !name || !artist || !rank) { return }
+            const songId = href.match(/data=([^&]+)/)?.[1];
+            const name = link.find('p.c-card-song__title').text().trim();
+            const artist = link.find('p.c-card-song__artist').text().trim();
 
-                songs.push({ 
-                    id: songId, 
-                    name: name,
-                    artist: artist,
-                    rank: rank
-                });
-            }
-            if (isArtistListGroupItem($(element))) {
-                // 見えていない要素は無視する
-                if (!isDisplay($(element))) { return }
+            songRank++;
 
-                const artistId = getArtistId($(element));
-                const name = getArtistName($(element));
-                const rank = getRankingNumber($(element));
+            if (!songId || !name || !artist) { return; }
 
-                if (!artistId || !name || !rank) { return }
+            songs.push({ id: songId, name, artist, rank: songRank });
+        });
 
-                artists.push({ 
-                    id: artistId, 
-                    name: name,
-                    rank: rank
-                });
-            }
+        // アーティストランキング（ul.c-card-artist）
+        $('ul.c-card-artist li.c-card-artist__item').each((_, element) => {
+            const link = $(element).find('a[href*="artist.php"]');
+            const href = link.attr('href') || '';
+
+            const artistId = href.match(/data=([^&]+)/)?.[1];
+            const name = link.find('p.c-card-artist__artist').text().trim();
+
+            artistRank++;
+
+            if (!artistId || !name) { return; }
+
+            artists.push({ id: artistId, name, rank: artistRank });
         });
 
         res.json({
@@ -69,7 +54,7 @@ exports.getHomeInfo = async (req, res) => {
         console.log(error)
         res.status(500).json({
             error: 'スクレイピングに失敗しました',
-            details: error.message 
+            details: error.message
         });
     }
 };

--- a/backend/implements/ranking-artists.js
+++ b/backend/implements/ranking-artists.js
@@ -1,51 +1,41 @@
 const express = require('express');
 
-const {
-    loadUrl,
-    isDisplay,
-    getRankingNumber,
-    isArtistListGroupItem,
-    getArtistId,
-    getArtistName
-} = require('../utils/cheerio');
-    
+const { loadUrl } = require('../utils/cheerio');
+
 const router = express.Router();
 
 exports.rankingArtists = async (req, res) => {
     try {
         const $ = await loadUrl(`https://www.ufret.jp/rank_artist.php`);
         const artists = [];
+        let rank = 0;
 
-        $('a.list-group-item').each((_, element) => {
-            // アーティスト以外は無視する
-            if (!isArtistListGroupItem($(element))) { return }
-            // 見えていない要素は無視する
-            if (!isDisplay($(element))) { return }
-            
-            const artistId = getArtistId($(element));
-            const name = getArtistName($(element));
-            const rank = getRankingNumber($(element));
-            
-            if (!artistId || !name || !rank) { return }
+        $('ul.c-list--rank li.c-list__item').each((_, element) => {
+            const link = $(element).find('a.c-list__link');
+            const href = link.attr('href') || '';
 
-            artists.push({ 
-                id: artistId, 
-                name: name,
-                rank: rank
-            });
+            // アーティスト以外は除外
+            if (!href.includes('artist.php')) { return; }
+
+            const artistId = href.match(/data=([^&]+)/)?.[1];
+            const name = link.find('p.c-list__title').text().trim();
+
+            rank++;
+
+            if (!artistId || !name) { return; }
+
+            artists.push({ id: artistId, name, rank });
         });
 
-        const count = artists.length;
-
         res.json({
-            artists: artists,
-            count: count,
+            artists,
+            count: artists.length,
         });
     } catch (error) {
         console.log(error)
         res.status(500).json({
             error: 'スクレイピングに失敗しました',
-            details: error.message 
+            details: error.message
         });
     }
 };

--- a/backend/implements/ranking-songs.js
+++ b/backend/implements/ranking-songs.js
@@ -1,57 +1,54 @@
 const express = require('express');
 
-const {
-    loadUrl,
-    isSongListGroupItem,
-    isDisplay,
-    getSongName,
-    getArtistNameOfSong,
-    getSongId,
-    getRankingNumber,
-    hasExcludeBadge
-} = require('../utils/cheerio');
-    
+const { loadUrl } = require('../utils/cheerio');
+
 const router = express.Router();
 
 exports.rankingSongs = async (req, res) => {
     try {
         const $ = await loadUrl(`https://www.ufret.jp/rank.php`);
         const songs = [];
+        let rank = 0;
 
-        $('a.list-group-item').each((_, element) => {
-            // 楽曲以外は無視する
-            if (!isSongListGroupItem($(element))) { return }
-            // 見えていない要素は無視する
-            if (!isDisplay($(element))) { return }
-            // 除外対象の場合は無視する
-            if (hasExcludeBadge($(element))) { return }
-            
-            const songId = getSongId($(element));
-            const name = getSongName($(element));
-            const artist = getArtistNameOfSong($(element));
-            const rank = getRankingNumber($(element));
-            
-            if (!songId || !name || !artist || !rank) { return }
+        // 表示中のタブ（週間ランキング）のコンテナを取得
+        const activeTabCont = $('div.js-tab-cont').filter((_, el) => {
+            const style = $(el).attr('style') || '';
+            return !style.includes('display: none') && !style.includes('display:none');
+        }).first();
 
-            songs.push({ 
-                id: songId, 
-                name: name,
-                artist: artist,
-                rank: rank
-            });
+        activeTabCont.find('li.c-list__item').each((_, element) => {
+            const li = $(element);
+
+            // 初心者verは除外
+            if (li.hasClass('beginner-chord')) { return; }
+
+            const link = li.find('a.c-list__link');
+            const href = link.attr('href') || '';
+
+            // 曲以外は除外
+            if (!href.includes('song.php')) { return; }
+
+            const songId = href.match(/data=([^&]+)/)?.[1];
+            // 子要素（初心者verバッジ等）を除いたテキストだけ取得
+            const name = link.find('p.c-list__title').clone().children().remove().end().text().trim();
+            const artist = link.find('p.c-list__artist').text().trim();
+
+            rank++;
+
+            if (!songId || !name || !artist) { return; }
+
+            songs.push({ id: songId, name, artist, rank });
         });
 
-        const count = songs.length;
-
         res.json({
-            songs: songs,
-            count: count,
+            songs,
+            count: songs.length,
         });
     } catch (error) {
         console.log(error)
         res.status(500).json({
             error: 'スクレイピングに失敗しました',
-            details: error.message 
+            details: error.message
         });
     }
 };

--- a/backend/implements/song.js
+++ b/backend/implements/song.js
@@ -24,15 +24,15 @@ exports.getSong = async (req, res) => {
             return {
                 title:
                     document
-                        .querySelector("span.show_name")
+                        .querySelector("h1.p-detail-head__ttl")
                         ?.textContent?.trim() || "",
                 artist:
                     document
-                        .querySelector("span.show_artist")
+                        .querySelector("a.p-detail-head__artist")
                         ?.textContent?.trim() || "",
                 credit:
                     document
-                        .querySelector("p.show_lyrics")
+                        .querySelector("p.p-detail-head__lyrics")
                         ?.textContent?.trim() || "",
             };
         });
@@ -78,13 +78,11 @@ exports.getSong = async (req, res) => {
         });
 
         // カポ（キー）の取得
-        const selectedCapoOption = await page.locator(
-            'select[name="keyselect"] option[selected]'
-        );
+        const keyInput = await page.locator('input[name="key_scrollbar"]').first();
         let selectedCapo = 0;
 
-        if ((await selectedCapoOption.count()) > 0) {
-            const value = await selectedCapoOption.getAttribute("value");
+        if ((await keyInput.count()) > 0) {
+            const value = await keyInput.getAttribute("value");
             if (value) {
                 const parsedKey = parseInt(value);
                 // 有効な範囲（-9から+2）かチェック


### PR DESCRIPTION
## Summary
- ufretのサイトリニューアルによるHTML構造変更に対応
- トップページ・ランキング・曲詳細ページのスクレイピングセレクターを修正

## 変更ファイル
- `backend/implements/home-info.js` — カード形式の新構造に対応（`ul.c-card-song` / `ul.c-card-artist`）
- `backend/implements/ranking-songs.js` — `a.list-group-item` → `li.c-list__item`、ランク番号をインデックスで算出
- `backend/implements/ranking-artists.js` — 同上（アーティスト版）
- `backend/implements/song.js` — タイトル・アーティスト・クレジットのセレクター修正、カポ取得方法の変更（`select` → `input[type=range]`）、strict mode エラー解消（`.first()` 追加）

## Test plan
- [ ] トップページの楽曲・アーティストランキングが表示されること
- [ ] 曲ランキングページが表示されること
- [ ] アーティストランキングページが表示されること
- [ ] 曲詳細ページが表示されること（コード譜・カポ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)